### PR TITLE
各 fetcher を route 文字列ベースのページネーションに切り替える

### DIFF
--- a/src/comments.rs
+++ b/src/comments.rs
@@ -75,19 +75,18 @@ impl UrlConstructor for CommentFetcher {
         format!("{}/{}", self.owner, self.name)
     }
 
-    fn entrypoint(&self) -> Option<Url> {
+    fn entrypoint_route(&self) -> String {
         let param = Params {
             since: self.since,
             ..Default::default()
         };
 
-        let route = format!(
+        format!(
             "repos/{owner}/{repo}/issues/comments?{query}",
             owner = &self.owner,
             repo = &self.name,
             query = param.to_query(),
-        );
-        self.octocrab.absolute_url(route).ok()
+        )
     }
 }
 
@@ -98,7 +97,11 @@ impl LoopWriter for CommentFetcher {
 
 impl CommentFetcher {
     pub async fn fetch<T: std::io::Write>(&self, mut wtr: csv::Writer<T>) -> octocrab::Result<()> {
-        let mut next: Option<Url> = self.entrypoint();
+        let first: octocrab::Page<Comment> = self
+            .octocrab
+            .get(self.entrypoint_route(), None::<&()>)
+            .await?;
+        let mut next = self.write_and_continue(first, &mut wtr);
 
         while let Some(page) = self.octocrab.get_page(&next).await? {
             next = self.write_and_continue(page, &mut wtr);

--- a/src/commits.rs
+++ b/src/commits.rs
@@ -135,19 +135,18 @@ impl UrlConstructor for CommitFetcher {
         format!("{}/{}", self.owner, self.name)
     }
 
-    fn entrypoint(&self) -> Option<Url> {
+    fn entrypoint_route(&self) -> String {
         let param = Params {
             since: self.since,
             ..Default::default()
         };
 
-        let route = format!(
+        format!(
             "repos/{owner}/{repo}/commits?{query}",
             owner = &self.owner,
             repo = &self.name,
             query = param.to_query(),
-        );
-        self.octocrab.absolute_url(route).ok()
+        )
     }
 }
 
@@ -158,7 +157,11 @@ impl LoopWriter for CommitFetcher {
 
 impl CommitFetcher {
     pub async fn fetch<T: std::io::Write>(&self, mut wtr: csv::Writer<T>) -> octocrab::Result<()> {
-        let mut next: Option<Url> = self.entrypoint();
+        let first: octocrab::Page<Commit> = self
+            .octocrab
+            .get(self.entrypoint_route(), None::<&()>)
+            .await?;
+        let mut next = self.write_and_continue(first, &mut wtr);
 
         while let Some(page) = self.octocrab.get_page(&next).await? {
             next = self.write_and_continue(page, &mut wtr);

--- a/src/events.rs
+++ b/src/events.rs
@@ -156,16 +156,15 @@ impl UrlConstructor for IssueEventFetcher {
         format!("{}/{}", self.owner, self.name)
     }
 
-    fn entrypoint(&self) -> Option<Url> {
+    fn entrypoint_route(&self) -> String {
         let param = Params::default();
 
-        let route = format!(
+        format!(
             "repos/{owner}/{repo}/issues/events?{query}",
             owner = &self.owner,
             repo = &self.name,
             query = param.to_query(),
-        );
-        self.octocrab.absolute_url(route).ok()
+        )
     }
 }
 
@@ -176,9 +175,13 @@ impl LoopWriter for IssueEventFetcher {
 
 impl IssueEventFetcher {
     pub async fn fetch<T: std::io::Write>(&self, mut wtr: csv::Writer<T>) -> octocrab::Result<()> {
-        let mut next: Option<Url> = self.entrypoint();
+        let first: octocrab::Page<IssueEvent> = self
+            .octocrab
+            .get(self.entrypoint_route(), None::<&()>)
+            .await?;
+        let mut page_opt = Some(first);
 
-        while let Some(mut page) = self.octocrab.get_page(&next).await? {
+        while let Some(mut page) = page_opt {
             let labels: Vec<IssueEvent> = page.take_items();
             let mut last_update: Option<DateTime> = None;
             for label in labels.into_iter() {
@@ -187,7 +190,7 @@ impl IssueEventFetcher {
                 wtr.serialize(&label).expect("Serialize failed");
                 last_update = label.created_at.into()
             }
-            next = if let Some(since) = self.since {
+            let next = if let Some(since) = self.since {
                 if last_update.unwrap() < since {
                     None
                 } else {
@@ -196,6 +199,7 @@ impl IssueEventFetcher {
             } else {
                 page.next
             };
+            page_opt = self.octocrab.get_page(&next).await?;
         }
 
         Ok(())

--- a/src/issues.rs
+++ b/src/issues.rs
@@ -129,20 +129,19 @@ impl UrlConstructor for IssueFetcher {
         format!("{}/{}", self.owner, self.name)
     }
 
-    fn entrypoint(&self) -> Option<Url> {
+    fn entrypoint_route(&self) -> String {
         let param = Params {
             state: octocrab::params::State::All.into(),
             since: self.since,
             ..Default::default()
         };
 
-        let route = format!(
+        format!(
             "repos/{owner}/{repo}/issues?{query}",
             owner = &self.owner,
             repo = &self.name,
             query = param.to_query(),
-        );
-        self.octocrab.absolute_url(route).ok()
+        )
     }
 }
 
@@ -153,7 +152,11 @@ impl LoopWriter for IssueFetcher {
 
 impl IssueFetcher {
     pub async fn fetch<T: std::io::Write>(&self, mut wtr: csv::Writer<T>) -> octocrab::Result<()> {
-        let mut next: Option<Url> = self.entrypoint();
+        let first: octocrab::Page<Issue> = self
+            .octocrab
+            .get(self.entrypoint_route(), None::<&()>)
+            .await?;
+        let mut next = self.write_and_continue(first, &mut wtr);
 
         while let Some(page) = self.octocrab.get_page(&next).await? {
             next = self.write_and_continue(page, &mut wtr);

--- a/src/labels.rs
+++ b/src/labels.rs
@@ -60,16 +60,15 @@ impl UrlConstructor for LabelFetcher {
         format!("{}/{}", self.owner, self.name)
     }
 
-    fn entrypoint(&self) -> Option<Url> {
+    fn entrypoint_route(&self) -> String {
         let param = Params::default();
 
-        let route = format!(
+        format!(
             "repos/{owner}/{repo}/labels?{query}",
             owner = &self.owner,
             repo = &self.name,
             query = param.to_query(),
-        );
-        self.octocrab.absolute_url(route).ok()
+        )
     }
 }
 
@@ -80,7 +79,11 @@ impl LoopWriter for LabelFetcher {
 
 impl LabelFetcher {
     pub async fn fetch<T: std::io::Write>(&self, mut wtr: csv::Writer<T>) -> octocrab::Result<()> {
-        let mut next: Option<Url> = self.entrypoint();
+        let first: octocrab::Page<Label> = self
+            .octocrab
+            .get(self.entrypoint_route(), None::<&()>)
+            .await?;
+        let mut next = self.write_and_continue(first, &mut wtr);
 
         while let Some(page) = self.octocrab.get_page(&next).await? {
             next = self.write_and_continue(page, &mut wtr);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@ pub trait RepositryAware {
 pub trait UrlConstructor {
     fn reponame(&self) -> String;
 
-    fn entrypoint(&self) -> Option<reqwest::Url>;
+    fn entrypoint_route(&self) -> String;
 }
 
 pub trait LoopWriter: UrlConstructor {

--- a/src/pulls.rs
+++ b/src/pulls.rs
@@ -126,29 +126,33 @@ impl PullFileFetcher {
 }
 
 impl PullFileFetcher {
-    pub async fn fetch<T: std::io::Write>(&self, mut wtr: csv::Writer<T>) -> octocrab::Result<()> {
+    fn pulls_route(&self) -> String {
         let param = Params::default();
-        let route = format!(
+        format!(
             "repos/{owner}/{repo}/pulls?{query}&state=all&sort=updated&direction=desc",
             owner = &self.owner,
             repo = &self.name,
             query = param.to_query(),
-        );
-        let mut next: Option<Url> = self.octocrab.absolute_url(route).ok();
+        )
+    }
 
-        while let Some(mut page) = self.octocrab.get_page(&next).await? {
+    pub async fn fetch<T: std::io::Write>(&self, mut wtr: csv::Writer<T>) -> octocrab::Result<()> {
+        let first: octocrab::Page<PullRequest> =
+            self.octocrab.get(&self.pulls_route(), None::<&()>).await?;
+        let mut page_opt = Some(first);
+
+        while let Some(mut page) = page_opt {
             let pulls: Vec<PullRequest> = page.take_items();
             let mut last_update: Option<DateTime<Utc>> = None;
             for pull in pulls.into_iter() {
-                let route = format!(
+                let files_route = format!(
                     "repos/{owner}/{repo}/pulls/{number}/files",
                     owner = &self.owner,
                     repo = &self.name,
                     number = pull.number,
                 );
-                let files_url: Url = self.octocrab.absolute_url(route).unwrap();
                 let mut files: Vec<PullRequestFile> =
-                    self.octocrab.get(&files_url, None::<&()>).await?;
+                    self.octocrab.get(&files_route, None::<&()>).await?;
                 for file in files.iter_mut() {
                     file.pull_request_number = pull.number.into();
                     file.sdc_repository = format!("{}/{}", self.owner, self.name).into();
@@ -159,7 +163,7 @@ impl PullFileFetcher {
                 last_update = Some(pull.updated_at.unwrap_or_else(|| pull.created_at));
             }
 
-            next = if let Some(since) = self.since {
+            let next = if let Some(since) = self.since {
                 if last_update.unwrap() < since {
                     None
                 } else {
@@ -168,6 +172,7 @@ impl PullFileFetcher {
             } else {
                 page.next
             };
+            page_opt = self.octocrab.get_page(&next).await?;
         }
 
         Ok(())
@@ -177,27 +182,22 @@ impl PullFileFetcher {
         &self,
         mut wtr: csv::Writer<T>,
     ) -> octocrab::Result<()> {
-        let param = Params::default();
-        let route = format!(
-            "repos/{owner}/{repo}/pulls?{query}&state=all&sort=updated&direction=desc",
-            owner = &self.owner,
-            repo = &self.name,
-            query = param.to_query(),
-        );
-        let mut next: Option<Url> = self.octocrab.absolute_url(route).ok();
+        let first: octocrab::Page<PullRequest> =
+            self.octocrab.get(&self.pulls_route(), None::<&()>).await?;
+        let mut page_opt = Some(first);
 
-        while let Some(mut page) = self.octocrab.get_page(&next).await? {
+        while let Some(mut page) = page_opt {
             let pulls: Vec<PullRequest> = page.take_items();
             let mut last_update: Option<DateTime<Utc>> = None;
             for pull in pulls.into_iter() {
-                let route = format!(
+                let commits_route = format!(
                     "repos/{owner}/{repo}/pulls/{number}/commits",
                     owner = &self.owner,
                     repo = &self.name,
                     number = pull.number,
                 );
-                let commits_url: Url = self.octocrab.absolute_url(route).unwrap();
-                let commits: Vec<Commit> = self.octocrab.get(&commits_url, None::<&()>).await?;
+                let commits: Vec<Commit> =
+                    self.octocrab.get(&commits_route, None::<&()>).await?;
                 for commit in commits.into_iter() {
                     let mut commit: PrCommitRec = commit.into();
                     commit.pull_request_number = pull.number.into();
@@ -209,7 +209,7 @@ impl PullFileFetcher {
                 last_update = Some(pull.updated_at.unwrap_or_else(|| pull.created_at));
             }
 
-            next = if let Some(since) = self.since {
+            let next = if let Some(since) = self.since {
                 if last_update.unwrap() < since {
                     None
                 } else {
@@ -218,6 +218,7 @@ impl PullFileFetcher {
             } else {
                 page.next
             };
+            page_opt = self.octocrab.get_page(&next).await?;
         }
 
         Ok(())

--- a/src/releases.rs
+++ b/src/releases.rs
@@ -112,16 +112,15 @@ impl UrlConstructor for ReleaseFetcher {
         format!("{}/{}", self.owner, self.name)
     }
 
-    fn entrypoint(&self) -> Option<Url> {
+    fn entrypoint_route(&self) -> String {
         let param = Params::default();
 
-        let route = format!(
+        format!(
             "repos/{owner}/{repo}/releases?{query}",
             owner = &self.owner,
             repo = &self.name,
             query = param.to_query(),
-        );
-        self.octocrab.absolute_url(route).ok()
+        )
     }
 }
 
@@ -132,7 +131,11 @@ impl LoopWriter for ReleaseFetcher {
 
 impl ReleaseFetcher {
     pub async fn fetch<T: std::io::Write>(&self, mut wtr: csv::Writer<T>) -> octocrab::Result<()> {
-        let mut next: Option<Url> = self.entrypoint();
+        let first: octocrab::Page<Release> = self
+            .octocrab
+            .get(self.entrypoint_route(), None::<&()>)
+            .await?;
+        let mut next = self.write_and_continue(first, &mut wtr);
 
         while let Some(page) = self.octocrab.get_page(&next).await? {
             next = self.write_and_continue(page, &mut wtr);

--- a/src/reviews.rs
+++ b/src/reviews.rs
@@ -111,16 +111,18 @@ impl ReviewFetcher {
 impl ReviewFetcher {
     pub async fn fetch<T: std::io::Write>(&self, mut wtr: csv::Writer<T>) -> octocrab::Result<()> {
         let param = Params::default();
-        let route = format!(
+        let pulls_route = format!(
             "repos/{owner}/{repo}/pulls?{query}&state=all&sort=updated&direction=desc",
             owner = &self.owner,
             repo = &self.name,
             query = param.to_query(),
         );
-        let mut next: Option<Url> = self.octocrab.absolute_url(route).ok();
+        let first: octocrab::Page<PullRequest> =
+            self.octocrab.get(&pulls_route, None::<&()>).await?;
+        let mut page_opt = Some(first);
 
         let mut pull_nums: Vec<u64> = vec![];
-        while let Some(mut page) = self.octocrab.get_page(&next).await? {
+        while let Some(mut page) = page_opt {
             let pulls: Vec<PullRequest> = page.take_items();
             let mut last_update: Option<DateTime<Utc>> = None;
             for pull in pulls.into_iter() {
@@ -128,7 +130,7 @@ impl ReviewFetcher {
                 last_update = Some(pull.updated_at.unwrap_or_else(|| pull.created_at));
             }
 
-            next = if let Some(since) = self.since {
+            let next = if let Some(since) = self.since {
                 last_update.map_or_else(
                     || None,
                     |last| {
@@ -142,19 +144,22 @@ impl ReviewFetcher {
             } else {
                 page.next
             };
+            page_opt = self.octocrab.get_page(&next).await?;
         }
 
         for number in pull_nums.into_iter() {
             let param = Params::default();
-            let route = format!(
+            let reviews_route = format!(
                 "repos/{owner}/{repo}/pulls/{pull_number}/reviews?{query}",
                 owner = &self.owner,
                 repo = &self.name,
                 pull_number = number,
                 query = param.to_query(),
             );
-            let mut next: Option<Url> = self.octocrab.absolute_url(route).ok();
-            while let Some(mut page) = self.octocrab.get_page(&next).await? {
+            let first: octocrab::Page<Review> =
+                self.octocrab.get(&reviews_route, None::<&()>).await?;
+            let mut page_opt = Some(first);
+            while let Some(mut page) = page_opt {
                 let reviews: Vec<Review> = page.take_items();
                 for review in reviews.into_iter() {
                     let mut review: ReviewRec = review.into();
@@ -163,7 +168,7 @@ impl ReviewFetcher {
 
                     wtr.serialize(review).expect("Serialize failed");
                 }
-                next = page.next;
+                page_opt = self.octocrab.get_page(&page.next).await?;
             }
         }
         Ok(())

--- a/src/users.rs
+++ b/src/users.rs
@@ -70,11 +70,10 @@ impl UrlConstructor for UserFetcher {
         "".to_string()
     }
 
-    fn entrypoint(&self) -> Option<Url> {
+    fn entrypoint_route(&self) -> String {
         let param = Params::default();
 
-        let route = format!("users?{query}", query = param.to_query());
-        self.octocrab.absolute_url(route).ok()
+        format!("users?{query}", query = param.to_query())
     }
 }
 
@@ -85,7 +84,11 @@ impl LoopWriter for UserFetcher {
 
 impl UserFetcher {
     pub async fn fetch<T: std::io::Write>(&self, mut wtr: csv::Writer<T>) -> octocrab::Result<()> {
-        let mut next: Option<Url> = self.entrypoint();
+        let first: octocrab::Page<User> = self
+            .octocrab
+            .get(self.entrypoint_route(), None::<&()>)
+            .await?;
+        let mut next = self.write_and_continue(first, &mut wtr);
 
         while let Some(page) = self.octocrab.get_page(&next).await? {
             next = self.write_and_continue(page, &mut wtr);

--- a/src/users_detailed.rs
+++ b/src/users_detailed.rs
@@ -49,15 +49,16 @@ impl UserDetailedFetcher {
     pub async fn fetch<T: std::io::Write>(&self, mut wtr: csv::Writer<T>) -> octocrab::Result<()> {
         let param = Params::default();
         let route = format!("users?{query}", query = param.to_query());
-        let mut next: Option<Url> = self.octocrab.absolute_url(route).ok();
+        let first: octocrab::Page<User> = self.octocrab.get(&route, None::<&()>).await?;
+        let mut page_opt = Some(first);
 
-        while let Some(mut page) = self.octocrab.get_page(&next).await? {
+        while let Some(mut page) = page_opt {
             let users: Vec<User> = page.take_items();
             for user in users.into_iter() {
                 let detail: UserDeailed = self.octocrab.get(&user.url, None::<&()>).await?;
                 wtr.serialize(&detail).expect("Serialize failed");
             }
-            next = page.next
+            page_opt = self.octocrab.get_page(&page.next).await?;
         }
 
         Ok(())

--- a/src/workflows.rs
+++ b/src/workflows.rs
@@ -259,16 +259,15 @@ impl UrlConstructor for WorkFlowFetcher {
         format!("{}/{}", self.owner, self.name)
     }
 
-    fn entrypoint(&self) -> Option<Url> {
+    fn entrypoint_route(&self) -> String {
         let param = Params::default();
 
-        let route = format!(
+        format!(
             "repos/{owner}/{repo}/actions/workflows?{query}",
             owner = &self.owner,
             repo = &self.name,
             query = param.to_query(),
-        );
-        self.octocrab.absolute_url(route).ok()
+        )
     }
 }
 
@@ -277,17 +276,16 @@ impl UrlConstructor for JobStepFetcher {
         format!("{}/{}", self.owner, self.name)
     }
 
-    fn entrypoint(&self) -> Option<Url> {
+    fn entrypoint_route(&self) -> String {
         let param = Params::default();
 
-        let route = format!(
+        format!(
             "repos/{owner}/{repo}/actions/jobs/{job_id}?{query}",
             owner = &self.owner,
             repo = &self.name,
             job_id = &self.job_id,
             query = param.to_query(),
-        );
-        self.octocrab.absolute_url(route).ok()
+        )
     }
 }
 
@@ -311,7 +309,11 @@ impl WorkFlowFetcher {
     }
 
     pub async fn fetch<T: std::io::Write>(&self, mut wtr: csv::Writer<T>) -> octocrab::Result<()> {
-        let mut next: Option<Url> = self.entrypoint();
+        let first: octocrab::Page<WorkFlow> = self
+            .octocrab
+            .get(self.entrypoint_route(), None::<&()>)
+            .await?;
+        let mut next = self.write_and_continue(first, &mut wtr);
 
         while let Some(page) = self.octocrab.get_page(&next).await? {
             next = self.write_and_continue(page, &mut wtr);
@@ -340,29 +342,26 @@ impl RunFetcher {
         format!("{}/{}", self.owner, self.name)
     }
 
-    fn entrypoint(&self, workflow_id: Option<String>) -> Option<Url> {
+    fn entrypoint_route(&self, workflow_id: Option<String>) -> String {
         let param = Params::default();
-        let route;
 
         if let Some(workflow_id_) = workflow_id {
-            route = format!(
+            format!(
                 "repos/{owner}/{repo}/actions/workflows/{workflow_id}/runs?{query}",
                 owner = &self.owner,
                 repo = &self.name,
                 workflow_id = &workflow_id_,
                 query = param.to_query(),
-            );
+            )
         } else {
             // FIXME: no way to sort runs by updated_at
-            route = format!(
+            format!(
                 "repos/{owner}/{repo}/actions/runs?{query}",
                 owner = &self.owner,
                 repo = &self.name,
                 query = param.to_query(),
             )
         }
-
-        self.octocrab.absolute_url(route).ok()
     }
 
     fn write_and_continue<T: std::io::Write>(
@@ -401,7 +400,11 @@ impl RunFetcher {
         mut wtr: csv::Writer<T>,
         workflow_id: Option<String>,
     ) -> octocrab::Result<()> {
-        let mut next: Option<Url> = self.entrypoint(workflow_id);
+        let first: octocrab::Page<Run> = self
+            .octocrab
+            .get(self.entrypoint_route(workflow_id), None::<&()>)
+            .await?;
+        let mut next = self.write_and_continue(first, &mut wtr);
 
         while let Some(page) = self.octocrab.get_page(&next).await? {
             next = self.write_and_continue(page, &mut wtr);
@@ -430,19 +433,18 @@ impl JobFetcher {
         format!("{}/{}", self.owner, self.name)
     }
 
-    fn entrypoint(&self, run_id: String) -> Option<Url> {
+    fn entrypoint_route(&self, run_id: String) -> String {
         let param = Params {
             filter: Some("all".to_string()),
             ..Default::default()
         };
-        let route = format!(
+        format!(
             "repos/{owner}/{repo}/actions/runs/{run_id}/jobs?{query}",
             owner = &self.owner,
             repo = &self.name,
             run_id = &run_id,
             query = param.to_query(),
-        );
-        self.octocrab.absolute_url(route).ok()
+        )
     }
 
     fn write_and_continue<T: std::io::Write>(
@@ -465,7 +467,11 @@ impl JobFetcher {
         run_id: Option<String>,
     ) -> octocrab::Result<()> {
         if let Some(run_id_) = run_id {
-            let mut next: Option<Url> = self.entrypoint(run_id_);
+            let first: octocrab::Page<Job> = self
+                .octocrab
+                .get(self.entrypoint_route(run_id_), None::<&()>)
+                .await?;
+            let mut next = self.write_and_continue(first, &mut wtr);
 
             while let Some(page) = self.octocrab.get_page(&next).await? {
                 next = self.write_and_continue(page, &mut wtr);
@@ -485,18 +491,29 @@ impl JobFetcher {
                 .await?
             {
                 let mut last_update: Option<DateTime> = None;
-                let mut run_url = run_fetcher.entrypoint(Some(workflow.id.to_string()));
-                while let Some(mut page) = self.octocrab.get_page(&run_url).await? {
+                let runs_first: octocrab::Page<Run> = self
+                    .octocrab
+                    .get(
+                        run_fetcher.entrypoint_route(Some(workflow.id.to_string())),
+                        None::<&()>,
+                    )
+                    .await?;
+                let mut run_page_opt = Some(runs_first);
+                while let Some(mut page) = run_page_opt {
                     let runs: Vec<Run> = page.take_items();
                     for run in runs.into_iter() {
-                        let mut job_url: Option<Url> = self.entrypoint(run.id.to_string());
+                        let job_first: octocrab::Page<Job> = self
+                            .octocrab
+                            .get(self.entrypoint_route(run.id.to_string()), None::<&()>)
+                            .await?;
+                        let mut job_url = self.write_and_continue(job_first, &mut wtr);
                         while let Some(page) = self.octocrab.get_page(&job_url).await? {
                             job_url = self.write_and_continue(page, &mut wtr);
                         }
                         last_update = Some(run.updated_at);
                     }
 
-                    run_url = if let Some(since) = self.since {
+                    let next = if let Some(since) = self.since {
                         last_update.map_or_else(
                             || None,
                             |last| {
@@ -510,6 +527,7 @@ impl JobFetcher {
                     } else {
                         page.next
                     };
+                    run_page_opt = self.octocrab.get_page(&next).await?;
                 }
             }
         }


### PR DESCRIPTION
## Summary

octocrab 最新版では `Octocrab::absolute_url()` が削除されており、次のメジャーバージョンアップに備えて、事前にこの依存を取り除きます。

## Changes

- `UrlConstructor` トレイトの `entrypoint() -> Option<Url>` を `entrypoint_route() -> String` に変更
- 各 fetcher の初回ページ取得を `self.octocrab.get(route_str, None::<&()>)` に書き換え。後続ページは従来どおり `get_page(&page.next)`
- octocrab 0.8.13 の `Octocrab::get<R, A: AsRef<str>, P>` は route 文字列を直接受け取れるため、今の octocrab のままでこの変更は成立します

## Review points

- `Cargo.toml` は変更なし。octocrab のバージョンは 0.8.13 のまま
- `reqwest::Url` の import は構造体のフィールド型として各所に残存しています。次のバージョンアップ PR で削除します
- 既存テスト (`src/issues.rs` の `test_convert_issue_model`) は無改修で通ります

## Context

octx に GitHub App installation token 認証を追加する準備として、3 本に分割した PR のうちの 1 本目です。2 本目で octocrab を 0.49.x に上げ、3 本目で App 認証を追加します。

本 PR では `Cargo.toml` の version は上げません。3 本マージ完了後にまとめて bump する想定です。

