### PR TITLE
GitHub App installation token 認証を追加

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -972,7 +972,7 @@ dependencies = [
 
 [[package]]
 name = "octx"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -980,6 +980,7 @@ dependencies = [
  "env_logger",
  "envy",
  "http",
+ "jsonwebtoken",
  "log",
  "octocrab",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ http = "1"
 chrono = { version = "^0.4", features = ["serde"] }
 anyhow = "1.0"
 octocrab = "0.49"
+jsonwebtoken = "10"
 tokio = { version = "1.0", default-features = false, features = ["macros", "rt-multi-thread", "time"] }
 serde = { version = "1.0.106", features = ["derive"] }
 serde_urlencoded = "0.7.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "octx"
-version = "0.6.2"
+version = "0.7.0"
 authors = ["Uchio Kondo <udzura@udzura.jp>"]
 repository = "https://github.com/pepabo/octx"
 keywords = ["github", "cli", "etl"]

--- a/README.md
+++ b/README.md
@@ -17,10 +17,15 @@ Instead of `GITHUB_API_TOKEN`, you can authenticate as a GitHub App
 installation. octx will obtain an installation token from the given
 App credentials and automatically refresh it before it expires.
 
+The private key is always read from a file on disk rather than from
+an environment variable, so that the raw PEM body is never exposed
+via the process environment (`/proc/<pid>/environ`, crash dumps, log
+output, etc.).
+
 ```bash
 $ export GITHUB_API_URL=https://...
 $ export GITHUB_APP_ID=12345
-$ export GITHUB_APP_PRIVATE_KEY="$(cat /path/to/private-key.pem)"
+$ export GITHUB_APP_PRIVATE_KEY_PATH=/path/to/private-key.pem
 $ export GITHUB_APP_INSTALLATION_ID=67890
 $ octx --issues rust-lang rust --days-ago 30
 ```

--- a/README.md
+++ b/README.md
@@ -5,11 +5,28 @@ GitHub Data Extractor [![Test](https://github.com/udzura/octx/actions/workflows/
 ## usage
 
 ```bash
-$ export GITHUB_API_TOKEN=...
 $ export GITHUB_API_URL=https://... # Optional
+$ export GITHUB_API_TOKEN=...       # Personal access token
 $ octx --issues rust-lang rust --days-ago 30
 # CSV will be put out to stdout
 ```
+
+### GitHub App installation token
+
+Instead of `GITHUB_API_TOKEN`, you can authenticate as a GitHub App
+installation. octx will obtain an installation token from the given
+App credentials and automatically refresh it before it expires.
+
+```bash
+$ export GITHUB_API_URL=https://...
+$ export GITHUB_APP_ID=12345
+$ export GITHUB_APP_PRIVATE_KEY="$(cat /path/to/private-key.pem)"
+$ export GITHUB_APP_INSTALLATION_ID=67890
+$ octx --issues rust-lang rust --days-ago 30
+```
+
+`GITHUB_API_TOKEN` and the three `GITHUB_APP_*` variables are mutually
+exclusive; set either one PAT or the full App triple.
 
 ## note
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -194,10 +194,10 @@ impl IssueEventFetcher {
                 if last_update.unwrap() < since {
                     None
                 } else {
-                    page.next
+                    page.next.map(to_relative_uri)
                 }
             } else {
-                page.next
+                page.next.map(to_relative_uri)
             };
             page_opt = self.octocrab.get_page(&next).await?;
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,20 @@ pub fn enum_to_string<T: serde::Serialize>(value: &T) -> String {
         .to_string()
 }
 
+// Drop scheme and authority from a pagination URI returned via GitHub's
+// `Link` header so octocrab's execute() treats it as a relative request.
+// GHES + App installation: octocrab only attaches the installation Bearer
+// token when the request authority is empty or exactly `api.github.com`,
+// so the absolute URL from `page.next` would otherwise be sent without
+// Authorization and fail with 401/403 on page 2+.
+pub fn to_relative_uri(uri: http::Uri) -> http::Uri {
+    use std::str::FromStr;
+    match uri.path_and_query() {
+        Some(paq) => http::Uri::from_str(paq.as_str()).unwrap_or(uri),
+        None => uri,
+    }
+}
+
 pub trait UrlConstructor {
     fn reponame(&self) -> String;
 
@@ -76,6 +90,6 @@ pub trait LoopWriter: UrlConstructor {
             label.set_repository(self.reponame());
             wtr.serialize(&label).expect("Serialize failed");
         }
-        page.next
+        page.next.map(to_relative_uri)
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,7 @@ use octx::{
 
     B) GitHub App installation token (auto-refreshed):
        GITHUB_APP_ID: numeric App ID
-       GITHUB_APP_PRIVATE_KEY: RSA PEM body (multi-line)
+       GITHUB_APP_PRIVATE_KEY_PATH: path to the RSA private key file (PEM)
        GITHUB_APP_INSTALLATION_ID: numeric installation ID
 
 EXAMPLE:
@@ -102,7 +102,7 @@ struct Env {
     github_api_token: Option<String>,
     github_api_url: String,
     github_app_id: Option<u64>,
-    github_app_private_key: Option<String>,
+    github_app_private_key_path: Option<String>,
     github_app_installation_id: Option<u64>,
 }
 
@@ -117,13 +117,16 @@ async fn main() -> octocrab::Result<()> {
     let octocrab = match (
         config.github_api_token,
         config.github_app_id,
-        config.github_app_private_key,
+        config.github_app_private_key_path,
         config.github_app_installation_id,
     ) {
         (Some(token), None, None, None) => builder.personal_token(token).build()?,
-        (None, Some(app_id), Some(pem), Some(installation_id)) => {
-            let key = jsonwebtoken::EncodingKey::from_rsa_pem(pem.as_bytes())
-                .context("while parsing GITHUB_APP_PRIVATE_KEY as RSA PEM")
+        (None, Some(app_id), Some(key_path), Some(installation_id)) => {
+            let pem = std::fs::read(&key_path)
+                .with_context(|| format!("while reading GITHUB_APP_PRIVATE_KEY_PATH={}", key_path))
+                .unwrap();
+            let key = jsonwebtoken::EncodingKey::from_rsa_pem(&pem)
+                .context("while parsing the private key file as RSA PEM")
                 .unwrap();
             builder
                 .app(octocrab::models::AppId(app_id), key)
@@ -132,7 +135,7 @@ async fn main() -> octocrab::Result<()> {
         }
         _ => panic!(
             "set either GITHUB_API_TOKEN or all of \
-             GITHUB_APP_ID, GITHUB_APP_PRIVATE_KEY, GITHUB_APP_INSTALLATION_ID"
+             GITHUB_APP_ID, GITHUB_APP_PRIVATE_KEY_PATH, GITHUB_APP_INSTALLATION_ID"
         ),
     };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,8 +18,17 @@ use octx::{
 #[derive(StructOpt)]
 /// GitHub query & extracter (Enterprise ready)
 #[structopt(after_help = "ENVIRONMENT VARIABLES:
-    GITHUB_API_TOKEN: *Required* Token for your github. PAT is OK
-    GITHUB_API_URL: Your enterprise server entrypoint. Please end the path with `/'
+    GITHUB_API_URL: *Required* Your GitHub API entrypoint. Please end the path with `/'
+
+    Provide ONE of the following authentication methods:
+
+    A) Personal access token:
+       GITHUB_API_TOKEN: PAT string
+
+    B) GitHub App installation token (auto-refreshed):
+       GITHUB_APP_ID: numeric App ID
+       GITHUB_APP_PRIVATE_KEY: RSA PEM body (multi-line)
+       GITHUB_APP_INSTALLATION_ID: numeric installation ID
 
 EXAMPLE:
     octx --issues rust-lang rust --days-ago 30
@@ -90,8 +99,11 @@ struct Command {
 
 #[derive(Deserialize, Debug)]
 struct Env {
-    github_api_token: String,
+    github_api_token: Option<String>,
     github_api_url: String,
+    github_app_id: Option<u64>,
+    github_app_private_key: Option<String>,
+    github_app_installation_id: Option<u64>,
 }
 
 #[tokio::main]
@@ -101,10 +113,28 @@ async fn main() -> octocrab::Result<()> {
         .context("while reading from environment")
         .unwrap();
     let args: Command = Command::from_args();
-    let octocrab = octocrab::Octocrab::builder()
-        .personal_token(config.github_api_token)
-        .base_uri(config.github_api_url)?
-        .build()?;
+    let builder = octocrab::Octocrab::builder().base_uri(config.github_api_url)?;
+    let octocrab = match (
+        config.github_api_token,
+        config.github_app_id,
+        config.github_app_private_key,
+        config.github_app_installation_id,
+    ) {
+        (Some(token), None, None, None) => builder.personal_token(token).build()?,
+        (None, Some(app_id), Some(pem), Some(installation_id)) => {
+            let key = jsonwebtoken::EncodingKey::from_rsa_pem(pem.as_bytes())
+                .context("while parsing GITHUB_APP_PRIVATE_KEY as RSA PEM")
+                .unwrap();
+            builder
+                .app(octocrab::models::AppId(app_id), key)
+                .build()?
+                .installation(octocrab::models::InstallationId(installation_id))?
+        }
+        _ => panic!(
+            "set either GITHUB_API_TOKEN or all of \
+             GITHUB_APP_ID, GITHUB_APP_PRIVATE_KEY, GITHUB_APP_INSTALLATION_ID"
+        ),
+    };
 
     let wtr = WriterBuilder::new()
         .has_headers(true)

--- a/src/pulls.rs
+++ b/src/pulls.rs
@@ -167,10 +167,10 @@ impl PullFileFetcher {
                 if last_update.unwrap() < since {
                     None
                 } else {
-                    page.next
+                    page.next.map(to_relative_uri)
                 }
             } else {
-                page.next
+                page.next.map(to_relative_uri)
             };
             page_opt = self.octocrab.get_page(&next).await?;
         }
@@ -213,10 +213,10 @@ impl PullFileFetcher {
                 if last_update.unwrap() < since {
                     None
                 } else {
-                    page.next
+                    page.next.map(to_relative_uri)
                 }
             } else {
-                page.next
+                page.next.map(to_relative_uri)
             };
             page_opt = self.octocrab.get_page(&next).await?;
         }

--- a/src/reviews.rs
+++ b/src/reviews.rs
@@ -137,12 +137,12 @@ impl ReviewFetcher {
                         if last < since {
                             None
                         } else {
-                            page.next
+                            page.next.map(to_relative_uri)
                         }
                     },
                 )
             } else {
-                page.next
+                page.next.map(to_relative_uri)
             };
             page_opt = self.octocrab.get_page(&next).await?;
         }
@@ -168,7 +168,8 @@ impl ReviewFetcher {
 
                     wtr.serialize(review).expect("Serialize failed");
                 }
-                page_opt = self.octocrab.get_page(&page.next).await?;
+                let next = page.next.map(to_relative_uri);
+                page_opt = self.octocrab.get_page(&next).await?;
             }
         }
         Ok(())

--- a/src/users_detailed.rs
+++ b/src/users_detailed.rs
@@ -1,3 +1,5 @@
+use std::str::FromStr;
+
 use chrono::{DateTime, Utc};
 use octocrab::models::Author as User;
 use url::Url;
@@ -55,7 +57,12 @@ impl UserDetailedFetcher {
         while let Some(mut page) = page_opt {
             let users: Vec<User> = page.take_items();
             for user in users.into_iter() {
-                let detail: UserDeailed = self.octocrab.get(&user.url, None::<&()>).await?;
+                let user_route = http::Uri::from_str(user.url.as_str())
+                    .map(to_relative_uri)
+                    .map(|u| u.to_string())
+                    .unwrap_or_else(|_| user.url.to_string());
+                let detail: UserDeailed =
+                    self.octocrab.get(user_route, None::<&()>).await?;
                 wtr.serialize(&detail).expect("Serialize failed");
             }
             let next = page.next.map(to_relative_uri);

--- a/src/users_detailed.rs
+++ b/src/users_detailed.rs
@@ -58,7 +58,8 @@ impl UserDetailedFetcher {
                 let detail: UserDeailed = self.octocrab.get(&user.url, None::<&()>).await?;
                 wtr.serialize(&detail).expect("Serialize failed");
             }
-            page_opt = self.octocrab.get_page(&page.next).await?;
+            let next = page.next.map(to_relative_uri);
+            page_opt = self.octocrab.get_page(&next).await?;
         }
 
         Ok(())

--- a/src/workflows.rs
+++ b/src/workflows.rs
@@ -388,12 +388,12 @@ impl RunFetcher {
                     if last < since {
                         None
                     } else {
-                        page.next
+                        page.next.map(to_relative_uri)
                     }
                 },
             )
         } else {
-            page.next
+            page.next.map(to_relative_uri)
         }
     }
 
@@ -460,7 +460,7 @@ impl JobFetcher {
             label.set_repository(self.reponame());
             wtr.serialize(&label).expect("Serialize failed");
         }
-        page.next
+        page.next.map(to_relative_uri)
     }
 
     pub async fn fetch<T: std::io::Write>(
@@ -522,12 +522,12 @@ impl JobFetcher {
                                 if last < since {
                                     None
                                 } else {
-                                    page.next
+                                    page.next.map(to_relative_uri)
                                 }
                             },
                         )
                     } else {
-                        page.next
+                        page.next.map(to_relative_uri)
                     };
                     run_page_opt = self.octocrab.get_page(&next).await?;
                 }


### PR DESCRIPTION
## Summary

GitHub App の installation token で認証できるようにします。

## Changes

- 環境変数を 3 つ追加しました。3 つすべて設定されていれば App 認証経路で Octocrab クライアントを作ります
  - `GITHUB_APP_ID`: App ID (整数)
  - `GITHUB_APP_PRIVATE_KEY_PATH`: App の秘密鍵 (RSA PEM) のファイルパス
  - `GITHUB_APP_INSTALLATION_ID`: Installation ID (整数)
- 既存の `GITHUB_API_TOKEN` と上記 3 変数は排他です。両方セットされている / 片方だけ中途半端に埋まっている状態は起動時に panic して弾きます
- `src/main.rs` の認証箇所を `Octocrab::builder().app(app_id, key).build()?.installation(installation_id)?` に切り替えました。 installation token は octocrab 側が送信直前にキャッシュ検証して必要なら自動で再発行します ( https://github.com/XAMPPRocky/octocrab/blob/v0.49.7/src/lib.rs 内の `CachedToken` 周辺)
- `Cargo.toml` に `jsonwebtoken = "10"` を追加しました。 `Octocrab::builder().app(AppId, EncodingKey)` が `jsonwebtoken::EncodingKey` を引数に取るためです (octocrab 0.49 側が `jsonwebtoken = "10"` を使っているのでバージョンを合わせています)
- README の usage セクションに GitHub App 認証の使い方を追記しました

## Review points

- PEM はファイル経由でのみ読み込みます。環境変数に直接 PEM 本文を入れる経路は意図的にサポートしていません。 `/proc/<pid>/environ` / クラッシュダンプ / 環境変数を拾うロガー / 子プロセスへの暗黙継承などで秘密鍵が漏れるリスクを減らしたかったためです。 Secret Manager → Cloud Run の連携でもファイルマウント方式 ( `--set-secrets "/secrets/github-app-key.pem=projects/.../secrets/.../versions/latest"` ) が使えます
- 排他チェックを `match` の全パターンで行い、不正な組み合わせで起動した場合は `panic!` で明示メッセージ出力にしています。 `anyhow::bail!` にする手もありましたが、 main の戻り値型を変えたくなかったので現状のまま panic にしています
- installation token の自動リフレッシュは octocrab 側に完全に委譲しています。自前で JWT を生成する必要はありません

## Context

octx に GitHub App installation token 認証を追加する 3 本立ての最終 PR です。

3 本立ての最後の PR として、本 PR で `Cargo.toml` の version を `0.6.2` → `0.7.0` に上げています。

