### PR TITLE
Release workflow を taiki-e/upload-rust-binary-action に差し替える

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,10 +13,11 @@ jobs:
       matrix:
         target: [x86_64-unknown-linux-musl]
     steps:
-      - uses: actions/checkout@master
-      - name: Compile and release
-        uses: Douile/rust-build.action@v0.1.26
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RUSTTARGET: ${{ matrix.target }}
-          EXTRA_FILES: "README.md LICENSE"
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - name: Upload binary to release
+        uses: taiki-e/upload-rust-binary-action@f0d45ae91ee7b8ee928de7a9d04d893a08bcbec6  # v1.30.2
+        with:
+          bin: octx
+          target: ${{ matrix.target }}
+          include: README.md,LICENSE
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,9 @@ jobs:
         target: [x86_64-unknown-linux-musl]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable (HEAD as of 2026-04-24)
+        with:
+          toolchain: stable
       - name: Upload binary to release
         uses: taiki-e/upload-rust-binary-action@f0d45ae91ee7b8ee928de7a9d04d893a08bcbec6  # v1.30.2
         with:


### PR DESCRIPTION
## Summary

0.7.0 のリリースワークフローが `Cargo.lock` を parse できずに失敗したのでリリース基盤を差し替えます。

## Background

0.7.0 の Release workflow run ( https://github.com/pepabo/octx/actions/runs/24889088596 ) は以下のエラーで失敗しました。

```
error: failed to parse lock file at: /github/workspace/Cargo.lock

Caused by:
  lock file version `4` was found, but this version of Cargo does not
  understand this lock file, perhaps Cargo needs to be updated?
```

現行の `Douile/rust-build.action@v0.1.26` は 2022 年の action で、同梱 Cargo が lockfile version 4 に対応していないのが原因です。recent な Rust toolchain ( 1.78 以降 ) で生成される `Cargo.lock` は v4 になります。なお、 `Douile/rust-build.action` の最新版である v1.4.5 (2024-02-25 リリース) でも Dockerfile が `FROM rust:1.76.0-alpine3.19` で固定されており、同じく lockfile v4 を parse できません。 

## Changes

- `Douile/rust-build.action` を `taiki-e/upload-rust-binary-action` に差し替えました。 cargo build から tar.gz/zip 圧縮・ sha256 checksum 生成・ GitHub Release への asset upload まで 1 step で扱えます
- build 直前に `dtolnay/rust-toolchain@stable` で stable toolchain を明示的にインストールして default に設定する step を挟みました
- `actions/checkout@master` から固定タグの SHA pin に変更
- すべての action を commit SHA で pin しました ( `actions/checkout` v6.0.2 → `de0fac2e4500dabe0009e67214ff5f5447ce83dd` 、 `dtolnay/rust-toolchain@stable` → `29eef336d9b2848a0b548edc03f92a220660cdb8` 、 `taiki-e/upload-rust-binary-action` v1.30.2 → `f0d45ae91ee7b8ee928de7a9d04d893a08bcbec6` )。タグは書き換え可能なためサプライチェーン攻撃対策として SHA pin を採用

### `dtolnay/rust-toolchain` を明示する理由

`taiki-e/upload-rust-binary-action` は内部で Rust toolchain をインストール **しない** 設計になっています ( `main.sh` 内では `rustup target add` を呼ぶだけ: https://github.com/taiki-e/upload-rust-binary-action/blob/v1.30.2/main.sh#L294 )。つまり runner にプリインストールされている Rust ( `rustup` ) の default toolchain が使われます。

- `ubuntu-latest` runner のプリインストール Rust は GitHub が定期的に更新しており、現在は 1.89 相当 ( https://github.com/actions/runner-images でイメージの履歴が確認できます)
- Rust 1.78 以降は lockfile v4 対応済みなので、現状の runner をそのまま使えば動きます
- ただし runner の更新方針変更や特定バージョン固定の runner を使った場合に壊れる potential が残ります

そこで `dtolnay/rust-toolchain@stable` を先に挟み、 `rustup toolchain install stable --profile minimal` + `rustup default stable` を明示的に実行することで、 runner のプリインストール状態に依存せず常に stable が使われる形にしています。

## Followup

- 本 PR マージ後に、既存の 0.7.0 リリース ( assets なしで作成済み ) を一度削除して再作成し、バイナリが添付される状態にします


