### PR TITLE
workflow runs の name / head_branch を Option<String> に変更

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -972,7 +972,7 @@ dependencies = [
 
 [[package]]
 name = "octx"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "octx"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Uchio Kondo <udzura@udzura.jp>"]
 repository = "https://github.com/pepabo/octx"
 keywords = ["github", "cli", "etl"]

--- a/src/api_ext.rs
+++ b/src/api_ext.rs
@@ -46,8 +46,11 @@ pub mod models {
         pub id: i64,
         pub workflow_id: i64,
         pub node_id: String,
-        pub name: String,
-        pub head_branch: String,
+        // GitHub の workflow runs API は、 workflow_dispatch /
+        // repository_dispatch などで起動された run について name や
+        // head_branch を null で返すことがある。
+        pub name: Option<String>,
+        pub head_branch: Option<String>,
         pub head_sha: String,
         pub run_number: i64,
         pub event: String,

--- a/src/workflows.rs
+++ b/src/workflows.rs
@@ -29,8 +29,8 @@ pub struct RunRec {
     pub id: i64,
     pub workflow_id: i64,
     pub node_id: String,
-    pub name: String,
-    pub head_branch: String,
+    pub name: Option<String>,
+    pub head_branch: Option<String>,
     pub head_sha: String,
     pub run_number: i64,
     pub event: String,  // TODO: to_enum


### PR DESCRIPTION
## 何を解決したいのか

GitHub の workflow runs API は workflow_dispatch / repository_dispatch などで起動された run について `name` や `head_branch` を null で返すことがある。 これまで `Run` および `RunRec` の同フィールドを non-optional な `String` として deserialize していたため、 該当する run を含むレスポンスを取得すると `"invalid type: null, expected a string"` の serde error で octx が失敗していた。

## 設計

`src/api_ext.rs` の `Run` と `src/workflows.rs` の `RunRec` の `name` / `head_branch` を `Option<String>` に変更する。 `From<Run> for RunRec` は同型同士の move なので追加修正は不要。 CSV 出力時、 null は空文字列としてレンダリングされる ( BigQuery の `--autodetect` は NULLABLE STRING として推論する )。

🤖 Generated with [Claude Code](https://claude.com/claude-code)