### PR TITLE
PR の base/head ref / repository metadata / user type を取得可能にする

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -972,7 +972,7 @@ dependencies = [
 
 [[package]]
 name = "octx"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "octx"
-version = "0.7.1"
+version = "0.7.2"
 authors = ["Uchio Kondo <udzura@udzura.jp>"]
 repository = "https://github.com/pepabo/octx"
 keywords = ["github", "cli", "etl"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,9 +10,10 @@ use std::io;
 extern crate octx;
 use octx::{
     comments::CommentFetcher, commits::CommitFetcher, events::IssueEventFetcher,
-    issues::IssueFetcher, labels::LabelFetcher, pulls::PullFileFetcher, releases::ReleaseFetcher,
-    reviews::ReviewFetcher, users::UserFetcher, users_detailed::UserDetailedFetcher,
-    workflows::JobFetcher, workflows::RunFetcher, workflows::WorkFlowFetcher,
+    issues::IssueFetcher, labels::LabelFetcher, pulls::PullFileFetcher, pulls::PullsFetcher,
+    releases::ReleaseFetcher, reviews::ReviewFetcher, users::UserFetcher,
+    users_detailed::UserDetailedFetcher, workflows::JobFetcher, workflows::RunFetcher,
+    workflows::WorkFlowFetcher,
 };
 
 #[derive(StructOpt)]
@@ -58,6 +59,9 @@ struct Command {
     /// Extract users - owner/name is not required for this option
     #[structopt(long = "users")]
     target_users: bool,
+    /// Extract pull requests with full detail (head/base refs, additions, deletions, user info etc.)
+    #[structopt(long = "pulls")]
+    target_pulls: bool,
     /// Extract Files included in pull requests
     #[structopt(long = "pull-request-files")]
     target_pull_files: bool,
@@ -179,6 +183,10 @@ async fn main() -> octocrab::Result<()> {
         } else if args.target_commits {
             info!("Target: commits");
             let runner = CommitFetcher::new(owner, name, since, octocrab);
+            runner.fetch(wtr).await?;
+        } else if args.target_pulls {
+            info!("Target: pulls");
+            let runner = PullsFetcher::new(owner, name, since, octocrab);
             runner.fetch(wtr).await?;
         } else if args.target_pull_files {
             info!("Target: pull files");

--- a/src/pulls.rs
+++ b/src/pulls.rs
@@ -6,6 +6,173 @@ use serde::*;
 use crate::commits::Commit;
 use crate::*;
 
+#[derive(Serialize, Debug)]
+pub struct PullRequestRec {
+    pub id: i64,
+    pub number: u64,
+    pub node_id: Option<String>,
+    pub url: String,
+    pub html_url: Option<String>,
+    pub state: Option<String>,
+    pub title: Option<String>,
+    pub body: Option<String>,
+    pub user_id: Option<i64>,
+    pub user_login: Option<String>,
+    pub user_type: Option<String>,
+    pub created_at: Option<DateTime<Utc>>,
+    pub updated_at: Option<DateTime<Utc>>,
+    pub closed_at: Option<DateTime<Utc>>,
+    pub merged_at: Option<DateTime<Utc>>,
+    pub merged: Option<bool>,
+    pub merged_by_id: Option<i64>,
+    pub merge_commit_sha: Option<String>,
+    pub head_ref: String,
+    pub head_sha: String,
+    pub base_ref: String,
+    pub base_sha: String,
+    pub base_repo_archived: Option<bool>,
+    pub base_repo_fork: Option<bool>,
+    pub base_repo_default_branch: Option<String>,
+    pub additions: Option<u64>,
+    pub deletions: Option<u64>,
+    pub changed_files: Option<u64>,
+    pub commits: Option<u64>,
+    pub author_association: Option<String>,
+    pub draft: Option<bool>,
+    pub locked: bool,
+    pub maintainer_can_modify: bool,
+
+    pub sdc_repository: String,
+}
+
+impl RepositryAware for PullRequestRec {
+    fn set_repository(&mut self, name: String) {
+        self.sdc_repository = name;
+    }
+}
+
+impl From<octocrab::models::pulls::PullRequest> for PullRequestRec {
+    fn from(p: octocrab::models::pulls::PullRequest) -> Self {
+        let user_login = p.user.as_ref().map(|u| u.login.clone());
+        let user_type = p.user.as_ref().map(|u| u.r#type.clone());
+        let user_id = p.user.as_ref().map(|u| u.id.0 as i64);
+        let base_repo_archived = p.base.repo.as_ref().and_then(|r| r.archived);
+        let base_repo_fork = p.base.repo.as_ref().and_then(|r| r.fork);
+        let base_repo_default_branch = p.base.repo.as_ref().and_then(|r| r.default_branch.clone());
+        Self {
+            id: p.id.0 as i64,
+            number: p.number,
+            node_id: p.node_id,
+            url: p.url,
+            html_url: p.html_url.map(|u| u.to_string()),
+            state: p.state.map(|s| format!("{:?}", s).to_lowercase()),
+            title: p.title,
+            body: p.body,
+            user_id,
+            user_login,
+            user_type,
+            created_at: p.created_at,
+            updated_at: p.updated_at,
+            closed_at: p.closed_at,
+            merged_at: p.merged_at,
+            merged: p.merged,
+            merged_by_id: p.merged_by.map(|u| u.id.0 as i64),
+            merge_commit_sha: p.merge_commit_sha,
+            head_ref: p.head.ref_field.clone(),
+            head_sha: p.head.sha.clone(),
+            base_ref: p.base.ref_field.clone(),
+            base_sha: p.base.sha.clone(),
+            base_repo_archived,
+            base_repo_fork,
+            base_repo_default_branch,
+            additions: p.additions,
+            deletions: p.deletions,
+            changed_files: p.changed_files,
+            commits: p.commits,
+            author_association: p.author_association.map(|a| format!("{:?}", a)),
+            draft: p.draft,
+            locked: p.locked,
+            maintainer_can_modify: p.maintainer_can_modify,
+            sdc_repository: String::default(),
+        }
+    }
+}
+
+pub struct PullsFetcher {
+    owner: String,
+    name: String,
+    since: Option<DateTime<Utc>>,
+    octocrab: octocrab::Octocrab,
+}
+
+impl PullsFetcher {
+    pub fn new(
+        owner: String,
+        name: String,
+        since: Option<DateTime<Utc>>,
+        octocrab: octocrab::Octocrab,
+    ) -> Self {
+        Self {
+            owner,
+            name,
+            since,
+            octocrab,
+        }
+    }
+
+    fn pulls_route(&self) -> String {
+        let param = Params::default();
+        format!(
+            "/repos/{owner}/{repo}/pulls?{query}&state=all&sort=updated&direction=desc",
+            owner = &self.owner,
+            repo = &self.name,
+            query = param.to_query(),
+        )
+    }
+
+    // additions / deletions / changed_files / commits は list endpoint では
+    // 返らないため、 list で番号を引いた後に detail endpoint を 1 件ずつ叩いて
+    // 完全な PR データを取得する。
+    pub async fn fetch<T: std::io::Write>(&self, mut wtr: csv::Writer<T>) -> octocrab::Result<()> {
+        let first: octocrab::Page<octocrab::models::pulls::PullRequest> =
+            self.octocrab.get(&self.pulls_route(), None::<&()>).await?;
+        let mut page_opt = Some(first);
+
+        while let Some(mut page) = page_opt {
+            let pulls = page.take_items();
+            let mut last_update: Option<DateTime<Utc>> = None;
+            for pull_summary in pulls.into_iter() {
+                let detail_route = format!(
+                    "/repos/{owner}/{repo}/pulls/{number}",
+                    owner = &self.owner,
+                    repo = &self.name,
+                    number = pull_summary.number,
+                );
+                let pull: octocrab::models::pulls::PullRequest =
+                    self.octocrab.get(&detail_route, None::<&()>).await?;
+
+                last_update = pull.updated_at.or(pull.created_at);
+                let mut rec: PullRequestRec = pull.into();
+                rec.set_repository(format!("{}/{}", self.owner, self.name));
+                wtr.serialize(&rec).expect("Serialize failed");
+            }
+
+            let next = if let Some(since) = self.since {
+                if last_update.is_some() && last_update.unwrap() < since {
+                    None
+                } else {
+                    page.next.map(to_relative_uri)
+                }
+            } else {
+                page.next.map(to_relative_uri)
+            };
+            page_opt = self.octocrab.get_page(&next).await?;
+        }
+
+        Ok(())
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct PullRequest {

--- a/src/pulls.rs
+++ b/src/pulls.rs
@@ -5,6 +5,7 @@ use serde::*;
 //use crate::commits::{Commit, GitCommit, GitUser, Object, UserId};
 use crate::commits::Commit;
 use crate::*;
+use octocrab::models::{AuthorAssociation, IssueState};
 
 #[derive(Serialize, Debug)]
 pub struct PullRequestRec {
@@ -13,7 +14,7 @@ pub struct PullRequestRec {
     pub node_id: Option<String>,
     pub url: String,
     pub html_url: Option<String>,
-    pub state: Option<String>,
+    pub state: Option<IssueState>,
     pub title: Option<String>,
     pub body: Option<String>,
     pub user_id: Option<i64>,
@@ -37,7 +38,7 @@ pub struct PullRequestRec {
     pub deletions: Option<u64>,
     pub changed_files: Option<u64>,
     pub commits: Option<u64>,
-    pub author_association: Option<String>,
+    pub author_association: Option<AuthorAssociation>,
     pub draft: Option<bool>,
     pub locked: bool,
     pub maintainer_can_modify: bool,
@@ -65,7 +66,7 @@ impl From<octocrab::models::pulls::PullRequest> for PullRequestRec {
             node_id: p.node_id,
             url: p.url,
             html_url: p.html_url.map(|u| u.to_string()),
-            state: p.state.map(|s| format!("{:?}", s).to_lowercase()),
+            state: p.state,
             title: p.title,
             body: p.body,
             user_id,
@@ -89,7 +90,7 @@ impl From<octocrab::models::pulls::PullRequest> for PullRequestRec {
             deletions: p.deletions,
             changed_files: p.changed_files,
             commits: p.commits,
-            author_association: p.author_association.map(|a| format!("{:?}", a)),
+            author_association: p.author_association,
             draft: p.draft,
             locked: p.locked,
             maintainer_can_modify: p.maintainer_can_modify,
@@ -142,6 +143,18 @@ impl PullsFetcher {
             let pulls = page.take_items();
             let mut last_update: Option<DateTime<Utc>> = None;
             for pull_summary in pulls.into_iter() {
+                let summary_updated = pull_summary.updated_at.or(pull_summary.created_at);
+                last_update = summary_updated;
+
+                // list endpoint の updated_at で since を満たさない PR は
+                // detail を叩かずスキップする ( 増分取り込みで detail call 数を抑える ) 。
+                // last_update は更新済みなのでループ末尾の打ち切り判定は引き続き機能する。
+                if let Some(since) = self.since {
+                    if summary_updated.map_or(false, |u| u < since) {
+                        continue;
+                    }
+                }
+
                 let detail_route = format!(
                     "/repos/{owner}/{repo}/pulls/{number}",
                     owner = &self.owner,
@@ -151,7 +164,6 @@ impl PullsFetcher {
                 let pull: octocrab::models::pulls::PullRequest =
                     self.octocrab.get(&detail_route, None::<&()>).await?;
 
-                last_update = pull.updated_at.or(pull.created_at);
                 let mut rec: PullRequestRec = pull.into();
                 rec.set_repository(format!("{}/{}", self.owner, self.name));
                 wtr.serialize(&rec).expect("Serialize failed");

--- a/src/pulls.rs
+++ b/src/pulls.rs
@@ -150,7 +150,7 @@ impl PullsFetcher {
                 // detail を叩かずスキップする ( 増分取り込みで detail call 数を抑える ) 。
                 // last_update は更新済みなのでループ末尾の打ち切り判定は引き続き機能する。
                 if let Some(since) = self.since {
-                    if summary_updated.map_or(false, |u| u < since) {
+                    if summary_updated.is_some_and(|u| u < since) {
                         continue;
                     }
                 }
@@ -170,7 +170,7 @@ impl PullsFetcher {
             }
 
             let next = if let Some(since) = self.since {
-                if last_update.map_or(false, |u| u < since) {
+                if last_update.is_some_and(|u| u < since) {
                     None
                 } else {
                     page.next.map(to_relative_uri)

--- a/src/pulls.rs
+++ b/src/pulls.rs
@@ -170,7 +170,7 @@ impl PullsFetcher {
             }
 
             let next = if let Some(since) = self.since {
-                if last_update.is_some() && last_update.unwrap() < since {
+                if last_update.map_or(false, |u| u < since) {
                     None
                 } else {
                     page.next.map(to_relative_uri)


### PR DESCRIPTION
## 何を解決したいのか

GitHub Issues API ベースの `--issues` model では PR の base_ref / head_ref や additions / deletions が取得できない。
PR detail endpoint ( GET /pulls/{number} ) を叩く新しい `--pulls` model を追加して、 PR 単位の詳細情報を抽出できるようにする。

## 設計

`PullsFetcher`:

- list endpoint で PR 一覧を更新日時降順で取得
- 各 PR について detail endpoint を 1 件ずつ叩いて完全データ ( additions / deletions / changed_files / commits は detail でのみ返るため ) を取得
- `--since` で更新日時の下限指定可能 ( 既存 pattern と同じ )

`PullRequestRec` ( CSV 出力 ):

- 基本属性 + branch refs ( head/base )
- `base.repo` から `archived` / `fork` / `default_branch` を抽出
- `user` から `user_id` / `user_login` / `user_type` を抽出 ( bot 判定用 )

## API コール数

1 ページ ( 100 PR ) ごとに 1 ( list ) + 100 ( detail ) ≒ 101 calls 。 GitHub の rate limit ( 5000/h ) に対して大規模リポでも余裕あり。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
