### PR TITLE
rate limit に達したら reset まで待って再試行する

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -117,10 +117,6 @@ async fn main() -> octocrab::Result<()> {
         .context("while reading from environment")
         .unwrap();
     let args: Command = Command::from_args();
-    // デフォルトの RetryConfig::Simple は transient エラーの即時リトライのみで、
-    // GitHub の rate limit には対応しない。 大量の API を叩く backfill 用途では
-    // primary rate limit ( 403 ) に達するため、 rate limit ヘッダ ( x-ratelimit-reset
-    // / retry-after ) を見て reset まで待ってから再試行する HandleRateLimits を使う。
     let builder = octocrab::Octocrab::builder()
         .base_uri(config.github_api_url)?
         .add_retry_config(

--- a/src/main.rs
+++ b/src/main.rs
@@ -117,7 +117,21 @@ async fn main() -> octocrab::Result<()> {
         .context("while reading from environment")
         .unwrap();
     let args: Command = Command::from_args();
-    let builder = octocrab::Octocrab::builder().base_uri(config.github_api_url)?;
+    // デフォルトの RetryConfig::Simple は transient エラーの即時リトライのみで、
+    // GitHub の rate limit には対応しない。 大量の API を叩く backfill 用途では
+    // primary rate limit ( 403 ) に達するため、 rate limit ヘッダ ( x-ratelimit-reset
+    // / retry-after ) を見て reset まで待ってから再試行する HandleRateLimits を使う。
+    let builder = octocrab::Octocrab::builder()
+        .base_uri(config.github_api_url)?
+        .add_retry_config(
+            octocrab::service::middleware::retry::RetryConfig::HandleRateLimits {
+                metrics: std::sync::Arc::new(
+                    octocrab::service::middleware::retry::NoOpRateLimitMetrics,
+                ),
+                max_retries: 5,
+                min_wait_seconds: 60,
+            },
+        );
     let octocrab = match (
         config.github_api_token,
         config.github_app_id,


### PR DESCRIPTION
## 何を解決するか

octx が GitHub の rate limit に達したときに、reset を待たず即座に失敗してしまう問題を解消します。

大量の API を叩く用途で primary rate limit（403 `API rate limit exceeded`）に達すると、デフォルトの `RetryConfig::Simple` は transient エラーの即時リトライしか行わないため、各リクエストがそのまま失敗し、取得データが途中で欠落していました。

## 変更内容

octocrab 0.49 の `RetryConfig::HandleRateLimits` をビルダーに設定します。これにより 403/429 + rate limit ヘッダ（`x-ratelimit-reset` / `retry-after`）を検知したとき、reset 期間まで待ってから自動で再試行します。

```rust
.add_retry_config(
    octocrab::service::middleware::retry::RetryConfig::HandleRateLimits {
        metrics: std::sync::Arc::new(NoOpRateLimitMetrics),
        max_retries: 5,
        min_wait_seconds: 60,
    },
)
```

## レビューポイント

- `octocrab` は default features に `retry` を含むため追加の feature 指定は不要です。
- `max_retries: 5` は 1 リクエストあたりの再試行回数です（rate limit 待ち後の再開を含む）。`min_wait_seconds: 60` は 429 でヘッダが無い場合のフォールバック待機です。
