### PR TITLE
rate limit retry と repository スコープ token 対応の octocrab fork を使う

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -931,8 +931,7 @@ dependencies = [
 [[package]]
 name = "octocrab"
 version = "0.49.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63f6687a23731011d0117f9f4c3cdabaa7b5e42ca671f42b5cc0657c492540e3"
+source = "git+https://github.com/zaimy/octocrab?branch=interim%2Foctx-0.49#f9b7b62d02a02ad785bb391553ffd7339a6363c3"
 dependencies = [
  "arc-swap",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -931,7 +931,7 @@ dependencies = [
 [[package]]
 name = "octocrab"
 version = "0.49.7"
-source = "git+https://github.com/zaimy/octocrab?branch=interim%2Foctx-0.49#f9b7b62d02a02ad785bb391553ffd7339a6363c3"
+source = "git+https://github.com/zaimy/octocrab?branch=interim%2Foctx-0.49#e1b66b270e633d3b51353c325d16982581b0257b"
 dependencies = [
  "arc-swap",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ url = { version = "^2.0", features = ["serde"] }
 http = "1"
 chrono = { version = "^0.4", features = ["serde"] }
 anyhow = "1.0"
-octocrab = "0.49"
+octocrab = { git = "https://github.com/zaimy/octocrab", branch = "interim/octx-0.49" }
 jsonwebtoken = "10"
 tokio = { version = "1.0", default-features = false, features = ["macros", "rt-multi-thread", "time"] }
 serde = { version = "1.0.106", features = ["derive"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -117,7 +117,18 @@ async fn main() -> octocrab::Result<()> {
         .context("while reading from environment")
         .unwrap();
     let args: Command = Command::from_args();
-    let builder = octocrab::Octocrab::builder().base_uri(config.github_api_url)?;
+    let builder = octocrab::Octocrab::builder()
+        .base_uri(config.github_api_url)?
+        .add_retry_config(
+            octocrab::service::middleware::retry::RetryConfig::HandleRateLimits {
+                metrics: std::sync::Arc::new(
+                    octocrab::service::middleware::retry::NoOpRateLimitMetrics,
+                ),
+                max_retries: 5,
+                min_wait_seconds: 60,
+                retry_on_forbidden: true,
+            },
+        );
     let octocrab = match (
         config.github_api_token,
         config.github_app_id,
@@ -132,10 +143,15 @@ async fn main() -> octocrab::Result<()> {
             let key = jsonwebtoken::EncodingKey::from_rsa_pem(&pem)
                 .context("while parsing the private key file as RSA PEM")
                 .unwrap();
-            builder
-                .app(octocrab::models::AppId(app_id), key)
-                .build()?
-                .installation(octocrab::models::InstallationId(installation_id))?
+            let app_crab = builder.app(octocrab::models::AppId(app_id), key).build()?;
+            let installation_id = octocrab::models::InstallationId(installation_id);
+            match args.name {
+                Some(ref name) => app_crab
+                    .installation_builder(installation_id)
+                    .repositories(vec![name.clone()])
+                    .build()?,
+                None => app_crab.installation(installation_id)?,
+            }
         }
         _ => panic!(
             "set either GITHUB_API_TOKEN or all of \


### PR DESCRIPTION
## 概要

octocrab の依存を、2 つの改善を入れた fork ブランチ（v0.49.7 ベース）に向け、octx でそれらを使う。改善は upstream octocrab に提案済み（ https://github.com/XAMPPRocky/octocrab/issues/928 ）だが取り込み前のため、暫定として fork に依存する。

- rate limit retry。retry policy を `HandleRateLimits` に切り替え、`retry_on_forbidden` を有効にする。secondary rate limit の 403 を `min_wait` 待って retry し、HTTP レスポンス到達前の transport error も retry する（`Simple` と同等の挙動）。長時間・大量の取得でも、rate limit や一時的な接続失敗で呼び出しが途中失敗しにくくなる。
- repository スコープ token。App 認証で repository 名が渡されたとき、installation token をその repository に限定して発行する（権限最小化）。スコープは保持されるので、octocrab の自動更新も同じスコープで再発行される。owner/name を取らない `--users` / `--users-detailed` では、従来どおり installation 全体スコープにフォールバックする。
- installation token の 401 リカバリ。installation token は発行から約 1 時間で失効する。rate limit の待機（`min_wait`、primary では reset まで）が token の残り寿命を超えると、retry は同じ失効 token を再送して 401 になり、401 は retry 対象外のため処理が頓挫していた。fork 側で、installation 認証時に 401 を受けたら token を再発行して元リクエストを 1 回だけ再送するようにした。これにより長い待機をまたいでも新しい token で継続できる。

## 変更点

- `Cargo.toml`。`octocrab` を crates.io から fork の git 依存（`interim/octx-0.49` ブランチ）に変更
- `Cargo.lock`。fork commit に更新（`--locked` ビルドのため）
- `src/main.rs`。共通 builder に retry policy を付与し、App 認証時に repository スコープ token を発行

## 補足

暫定対応。upstream octocrab に取り込まれたら、crates.io の新バージョン依存に戻す想定。

## 依存する octocrab fork の差分

octx が依存する fork ブランチ `interim/octx-0.49` の v0.49.7 からの差分（ retry policy、repository スコープ token、installation token の 401 リカバリの 3 コミット）。

[v0.49.7...interim/octx-0.49](https://github.com/XAMPPRocky/octocrab/compare/v0.49.7...zaimy:interim/octx-0.49)
